### PR TITLE
fix: use GITHUB_OUTPUT instead of set-output command

### DIFF
--- a/.github/workflows/scaffold.yaml
+++ b/.github/workflows/scaffold.yaml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ${{env.SERVICE}}
 
       - run: |
-          echo "::set-output name=branch::scaffold-${SERVICE}-$(date +%Y%m%dT%H%M%S)"
+          echo "branch=scaffold-${SERVICE}-$(date +%Y%m%dT%H%M%S)" >> "$GITHUB_OUTPUT"
         id: branch
 
       - run: |


### PR DESCRIPTION
set-output was deprecated.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/